### PR TITLE
fix vite example

### DIFF
--- a/examples/vite/vite.config.ts
+++ b/examples/vite/vite.config.ts
@@ -14,10 +14,20 @@ export default defineConfig({
     // Another workaround for Vite bug: https://github.com/radix-ui/primitives/discussions/1915#discussioncomment-5733178
     include: ["react-dom"],
   },
-  // assets lazily loaded by evolu
-  assetsInclude: [/@scure\/bip39/],
+  build: {
+    rollupOptions: {
+      // lazily loaded modules
+      external: [/@scure\/bip39/],
+    },
+  },
   worker: {
     format: "es",
+  },
+  preview: {
+    headers: {
+      "Cross-Origin-Opener-Policy": "same-origin",
+      "Cross-Origin-Embedder-Policy": "require-corp",
+    },
   },
   plugins: [
     react(),


### PR DESCRIPTION
previous vite "fix" was making the build pass, but resulting app did not bundle lazily loaded modules properly, since they need to be marked as external in rollup which is used by vite for production builds 