### PR TITLE
Fix Schema links on Quickstart page

### DIFF
--- a/apps/web/pages/docs/quickstart.mdx
+++ b/apps/web/pages/docs/quickstart.mdx
@@ -11,7 +11,7 @@ Let's learn how to use Evolu in a few steps.
 First, we define a database schema: tables, columns, and their types.
 
 <Callout>
-  Evolu uses [Schema](https://github.com/effect-ts/schema) for data modeling.
+  Evolu uses [Schema](https://github.com/Effect-TS/effect/blob/main/packages/schema) for data modeling.
   Instead of plain JavaScript types like String or Number, we recommend [branded
   types](https://www.effect.website/docs/style/brands). With branded types, we
   can define and enforce domain rules like `NonEmptyString1000` or
@@ -59,7 +59,7 @@ import { NonEmptyString1000 } from "@evolu/react";
 S.decode(NonEmptyString1000)(title);
 ```
 
-Learn more about [Schema](https://github.com/effect-ts/schema).
+Learn more about [Schema](https://github.com/Effect-TS/effect/blob/main/packages/schema).
 It's like [Zod](https://zod.dev), but faster and with better design.
 
 ### Mutate Data


### PR DESCRIPTION
They now point to the correct page in the Effect monorepo instead of to the archived old repo