### PR TITLE
updated docs example without react

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ dist-ssr
 *.local
 .env
 .cache
+.idea
 server/dist
 public/dist
 storybook-static/

--- a/apps/web/pages/docs/api.mdx
+++ b/apps/web/pages/docs/api.mdx
@@ -6,6 +6,7 @@ Packages for app development:
 
 - `@evolu/react`
 - `@evolu/react-native`
+- `@evolu/common-web` (All other Frameworks)
 
 To define the Evolu database schema reusable for platforms, use `@evolu/common`.
 

--- a/apps/web/pages/docs/installation.mdx
+++ b/apps/web/pages/docs/installation.mdx
@@ -26,7 +26,7 @@ Examples: [Next.js](https://github.com/evoluhq/evolu/tree/main/examples/nextjs),
 
 ### Install Evolu
 
-<Tabs items={["React", "React Native"]}>
+<Tabs items={["React", "React Native", "All other Frameworks"]}>
   <Tabs.Tab>
 
     ```bash filename="Terminal"
@@ -38,6 +38,13 @@ Examples: [Next.js](https://github.com/evoluhq/evolu/tree/main/examples/nextjs),
 
     ```bash filename="Terminal"
       npm install @evolu/react-native
+    ```
+
+  </Tabs.Tab>
+  <Tabs.Tab>
+
+    ```bash filename="Terminal"
+      npm install @evolu/common @evolu/common-web
     ```
 
   </Tabs.Tab>

--- a/apps/web/pages/index.mdx
+++ b/apps/web/pages/index.mdx
@@ -38,10 +38,18 @@ import {
   NonEmptyString1000,
   SqliteBoolean,
   cast,
-  createEvolu,
   database,
   id,
   table,
+  // can be also imported from "@evolu/react"
+} from "@evolu/common";
+
+// Without React
+import { createEvolu } from "@evolu/common-web";
+
+// With React
+import {
+  createEvolu,
   useEvolu,
   useQuery,
 } from "@evolu/react";
@@ -80,6 +88,8 @@ const allTodos = evolu.createQuery((db) =>
 // Load the query. Batched and cached by default.
 const allTodosPromise = evolu.loadQuery(allTodos);
 
+// React Helper Functions
+
 // Use the query in React reactively (it's updated on a mutation).
 const { rows } = useQuery(allTodos);
 
@@ -96,8 +106,24 @@ update("todo", { id, isCompleted: true });
 // Delete all data on a device.
 useEvolu().resetOwner();
 
-// Restore all data on a different defice.
+// Restore all data on a different device.
 useEvolu().restoreOwner(mnemonic);
+
+// All other Frameworks
+
+// Create a todo.
+evolu.create("todo", {
+  title: S.decodeSync(NonEmptyString1000)("Learn Effect"),
+});
+
+// Update a todo.
+evolu.update("todo", { id, isCompleted: true });
+
+// Delete all data on a device.
+evolu.resetOwner();
+
+// Restore all data on a different device.
+evolu.restoreOwner(mnemonic);
 ```
 
 ## Community

--- a/packages/evolu-common-web/src/index.ts
+++ b/packages/evolu-common-web/src/index.ts
@@ -1,7 +1,9 @@
 import {
   Bip39,
   EvoluCommonLive,
+  FlushSyncDefaultLive,
   InvalidMnemonicError,
+  makeCreateEvolu,
   Mnemonic,
 } from "@evolu/common";
 import * as Effect from "effect/Effect";
@@ -25,3 +27,37 @@ export const parseMnemonic: (
   Effect.provide(Bip39Live),
   Effect.runSync,
 ).parse;
+
+
+/**
+ * Create Evolu Instance.
+ *
+ * Tables with a name prefixed with `_` are local-only, which means they are
+ * never synced. It's useful for device-specific or temporal data.
+ *
+ * @example
+ *   import * as S from "@effect/schema/Schema";
+ *   import { NonEmptyString1000, id } from "@evolu/common";
+ *   import { createEvolu } from "@evolu/common-web";
+ *
+ *   const TodoId = id("Todo");
+ *   type TodoId = S.Schema.To<typeof TodoId>;
+ *
+ *   const TodoTable = table({
+ *     id: TodoId,
+ *     title: NonEmptyString1000,
+ *   });
+ *   type TodoTable = S.Schema.To<typeof TodoTable>;
+ *
+ *   const Database = database({
+ *     // _todo is local-only table
+ *     _todo: TodoTable,
+ *     todo: TodoTable,
+ *   });
+ *   type Database = S.Schema.To<typeof Database>;
+ *
+ *   const evolu = createEvolu(Database);
+ */
+export const createEvolu = makeCreateEvolu(
+  EvoluWebLive.pipe(Layer.provide(FlushSyncDefaultLive)),
+);


### PR DESCRIPTION
It took me a while when I found evolu that it was finally a library was not "only" for react 😬, so I think this way its a bit more clear now

I also added `createEvolu` for `common-web` otherwise I don't think everyone (unless they want to replace something) want to use the `makeCreateEvolu` Method itself

Sidenote: I couldn't fully run `turbo dev`/`turbo build` cause it was failing on missing `@evolu/server` and I couldn't figure out why