### PR TITLE
Provide `FlushSyncDefaultLive` by default in Evolu

### DIFF
--- a/packages/evolu-common-web/src/index.ts
+++ b/packages/evolu-common-web/src/index.ts
@@ -1,7 +1,6 @@
 import {
   Bip39,
   EvoluCommonLive,
-  FlushSyncDefaultLive,
   InvalidMnemonicError,
   makeCreateEvolu,
   Mnemonic,
@@ -56,6 +55,4 @@ export const parseMnemonic: (
  *
  *   const evolu = createEvolu(Database);
  */
-export const createEvolu = makeCreateEvolu(
-  EvoluWebLive.pipe(Layer.provide(FlushSyncDefaultLive)),
-);
+export const createEvolu = makeCreateEvolu(EvoluWebLive);

--- a/packages/evolu-common/src/Evolu.ts
+++ b/packages/evolu-common/src/Evolu.ts
@@ -31,7 +31,7 @@ import { EvoluError, makeErrorStore } from "./ErrorStore.js";
 import { SqliteBoolean, SqliteDate } from "./Model.js";
 import { OnCompletes, OnCompletesLive } from "./OnCompletes.js";
 import { Owner } from "./Owner.js";
-import { AppState, FlushSync } from "./Platform.js";
+import { AppState, FlushSync, FlushSyncDefaultLive } from "./Platform.js";
 import {
   Index,
   SqliteQuery,
@@ -800,6 +800,7 @@ const EvoluCommon = Layer.effect(
   }),
 ).pipe(
   Layer.provide(Layer.mergeAll(LoadQueryLive, OnQueryLive, MutateLive)),
+  Layer.provide(FlushSyncDefaultLive),
   Layer.provide(LoadingPromiseLive),
   Layer.provide(SubscribedQueriesLive),
   Layer.provide(Layer.merge(RowsStoreLive, OnCompletesLive)),

--- a/packages/evolu-react-native/src/index.ts
+++ b/packages/evolu-react-native/src/index.ts
@@ -3,7 +3,6 @@ import {
   DbWorkerCommonLive,
   EvoluCommonLive,
   FetchLive,
-  FlushSyncDefaultLive,
   InvalidMnemonicError,
   Mnemonic,
   NanoIdGeneratorLive,
@@ -64,9 +63,7 @@ export const parseMnemonic: (
  */
 export const createEvolu = makeCreateEvolu(
   EvoluCommonLive.pipe(
-    Layer.provide(
-      Layer.mergeAll(FlushSyncDefaultLive, AppStateLive, DbWorkerCommonLive),
-    ),
+    Layer.provide(Layer.mergeAll(AppStateLive, DbWorkerCommonLive)),
     Layer.provide(
       Layer.mergeAll(
         Bip39Live,


### PR DESCRIPTION
and provide a custom `FlushSync` layer if needed only. Not all implementations will do need such a thing, but `react` of course (no change for `@evolu/react`) ~~and maybe `@evolu/solid` later (see its [flushSync](https://github.com/solidjs/signals/blob/d14c3e6b0cb48267e84a39b9f5305c36d567154f/src/effect.ts#L14-L16))~~. 

Other evolu implementations (e.g. `@evolu/web` or `@evolu/react-native`) are still using an empty callback provided by  `FlushSyncDefaultLive` by default.