### PR TITLE
fix: `flashsync` default callback

### DIFF
--- a/packages/evolu-common/src/Evolu.ts
+++ b/packages/evolu-common/src/Evolu.ts
@@ -518,8 +518,9 @@ const OnQueryLive = Layer.effect(
     const rowsStore = yield* _(RowsStore);
     const loadingPromises = yield* _(LoadingPromises);
     const flushSync = pipe(
-      yield* _(Effect.serviceOption(FlushSync)),
-      O.getOrElse(():FlushSync => (callback) => callback())
+      Effect.serviceOption(FlushSync),
+      Effect.map(O.getOrElse(():FlushSync => (callback) => callback())),
+      Effect.runSync
     );
     const onCompletes = yield* _(OnCompletes);
 

--- a/packages/evolu-common/src/Evolu.ts
+++ b/packages/evolu-common/src/Evolu.ts
@@ -519,8 +519,8 @@ const OnQueryLive = Layer.effect(
     const loadingPromises = yield* _(LoadingPromises);
     const flushSync = pipe(
       Effect.serviceOption(FlushSync),
-      Effect.map(O.getOrElse(():FlushSync => (callback) => callback())),
-      Effect.runSync
+      Effect.map(O.getOrElse((): FlushSync => (callback) => callback())),
+      Effect.runSync,
     );
     const onCompletes = yield* _(OnCompletes);
 

--- a/packages/evolu-common/src/Platform.ts
+++ b/packages/evolu-common/src/Platform.ts
@@ -13,10 +13,6 @@ export type FlushSync = (callback: () => void) => void;
 
 export const FlushSync = Context.GenericTag<FlushSync>("@services/FlushSync");
 
-export const FlushSyncDefaultLive = Layer.succeed(FlushSync, (callback) =>
-  callback(),
-);
-
 export interface SyncLock {
   /**
    * Try to acquire a sync lock. The caller must not call sync if a sync lock


### PR DESCRIPTION
Just realized, but still not sure if this is an issue: In case `rowsStore.setState`  needs to be called in `OnQueryLive` every time , then this PR is a fix.

Also `FlushSyncDefaultLive` has been removed, since it's deprecated now.