### PR TITLE
Use `Option<EvoluError>`, `Option<Owner>`  instead of `null`able values

### DIFF
--- a/packages/evolu-common-react/src/useEvoluError.ts
+++ b/packages/evolu-common-react/src/useEvoluError.ts
@@ -1,14 +1,17 @@
+import * as O from "effect/Option";
+import { pipe } from "effect/Function";
 import { EvoluError } from "@evolu/common";
-import * as Function from "effect/Function";
 import { useSyncExternalStore } from "react";
 import { useEvolu } from "./useEvolu.js";
 
 /** Subscribe to {@link EvoluError} changes. */
 export const useEvoluError = (): EvoluError | null => {
   const evolu = useEvolu();
-  return useSyncExternalStore(
+  const oStore = useSyncExternalStore(
     evolu.subscribeError,
     evolu.getError,
-    Function.constNull,
+    (): O.Option<EvoluError> => O.none(),
   );
+
+  return pipe(oStore, O.getOrNull); 
 };

--- a/packages/evolu-common-react/src/useOwner.ts
+++ b/packages/evolu-common-react/src/useOwner.ts
@@ -1,14 +1,17 @@
+import * as O from "effect/Option";
 import { Owner } from "@evolu/common";
-import * as Function from "effect/Function";
+import { pipe } from "effect/Function";
 import { useSyncExternalStore } from "react";
 import { useEvolu } from "./useEvolu.js";
 
 /** Subscribe to {@link Owner} changes. */
 export const useOwner = (): Owner | null => {
   const evolu = useEvolu();
-  return useSyncExternalStore(
+  const oStore = useSyncExternalStore(
     evolu.subscribeOwner,
     evolu.getOwner,
-    Function.constNull,
+    (): O.Option<Owner> => O.none(),
   );
+
+  return pipe(oStore, O.getOrNull);
 };

--- a/packages/evolu-common/src/ErrorStore.ts
+++ b/packages/evolu-common/src/ErrorStore.ts
@@ -1,8 +1,9 @@
+import * as O from "effect/Option";
 import * as Effect from "effect/Effect";
 import { TimestampError } from "./Crdt.js";
 import { makeStore } from "./Store.js";
 
-export const makeErrorStore = makeStore<EvoluError | null>(null);
+export const makeErrorStore = makeStore<O.Option<EvoluError>>(O.none());
 
 /** The EvoluError type is used to represent errors that can occur in Evolu. */
 export type EvoluError = UnexpectedError | TimestampError;

--- a/packages/evolu-common/src/Evolu.ts
+++ b/packages/evolu-common/src/Evolu.ts
@@ -168,7 +168,7 @@ export interface Evolu<S extends DatabaseSchema = DatabaseSchema> {
    *     const owner = evolu.getOwner();
    *   });
    */
-  readonly subscribeOwner: Store<Owner | null>["subscribe"];
+  readonly subscribeOwner: Store<O.Option<Owner>>["subscribe"];
 
   /**
    * Get {@link Owner}.
@@ -178,7 +178,7 @@ export interface Evolu<S extends DatabaseSchema = DatabaseSchema> {
    *     const owner = evolu.getOwner();
    *   });
    */
-  readonly getOwner: Store<Owner | null>["getState"];
+  readonly getOwner: Store<O.Option<Owner>>["getState"];
 
   /**
    * Subscribe to {@link SyncState} changes.
@@ -731,7 +731,7 @@ const EvoluCommon = Layer.effect(
       makeStore<SyncState>({ _tag: "SyncStateInitial" }),
     );
     const mutate = yield* _(Mutate);
-    const ownerStore = yield* _(makeStore<Owner | null>(null));
+    const ownerStore = yield* _(makeStore<O.Option<Owner>>(O.none()));
     const loadingPromises = yield* _(LoadingPromises);
     const appState = yield* _(AppState);
 
@@ -740,7 +740,7 @@ const EvoluCommon = Layer.effect(
         Match.tagsExhaustive({
           onError: ({ error }) => errorStore.setState(error),
           onQuery,
-          onOwner: ({ owner }) => ownerStore.setState(owner),
+          onOwner: ({ owner }) => ownerStore.setState(O.some(owner)),
           onSyncState: ({ state }) => syncStateStore.setState(state),
           onReceive: () =>
             Effect.sync(() => {

--- a/packages/evolu-common/src/Evolu.ts
+++ b/packages/evolu-common/src/Evolu.ts
@@ -52,10 +52,10 @@ export interface Evolu<S extends DatabaseSchema = DatabaseSchema> {
    *     console.log(error);
    *   });
    */
-  readonly subscribeError: Store<EvoluError | null>["subscribe"];
+  readonly subscribeError: Store<O.Option<EvoluError>>["subscribe"];
 
   /** Get {@link EvoluError}. */
-  readonly getError: Store<EvoluError | null>["getState"];
+  readonly getError: Store<O.Option<EvoluError>>["getState"];
 
   /**
    * Create type-safe SQL {@link Query}.
@@ -738,7 +738,7 @@ const EvoluCommon = Layer.effect(
     dbWorker.onMessage = (output): void =>
       Match.value(output).pipe(
         Match.tagsExhaustive({
-          onError: ({ error }) => errorStore.setState(error),
+          onError: ({ error }) => errorStore.setState(O.some(error)),
           onQuery,
           onOwner: ({ owner }) => ownerStore.setState(O.some(owner)),
           onSyncState: ({ state }) => syncStateStore.setState(state),


### PR DESCRIPTION
**TL;DR** Needed for `@evolu/solid` (and maybe helpful for other implementations). 

Going this way any implementation for Evolu can decide to express `Option` as `null` or `undefined` or anything else. 

For example: `useOwner` for `React` returns `Owner | null`. No change here. But for `Solid` (see #376) `null` are not valid initial values for Solid stores (see [`createstore`](https://www.solidjs.com/docs/latest/api#createstore)). 

With this PR [useSyncEvoluStore](https://github.com/evoluhq/evolu/blob/f482d43aaafb8190ee67a9a9173a003b101b5a14/packages/evolu-solid/src/useSyncEvoluStore.ts) and [useSyncNullableEvoluStore](https://github.com/evoluhq/evolu/blob/f482d43aaafb8190ee67a9a9173a003b101b5a14/packages/evolu-solid/src/useSyncNullableEvoluStore.ts) can be merged easily into a single `useSyncEvoluStore`.
