### PR TITLE
Fix link on docs/Installation page

### DIFF
--- a/apps/web/pages/docs/installation.mdx
+++ b/apps/web/pages/docs/installation.mdx
@@ -45,7 +45,8 @@ Requirements:
 ### Check Examples
 
 Examples: [Next.js](https://github.com/evoluhq/evolu/tree/main/examples/nextjs),
-[Vite](https://github.com/evoluhq/evolu/tree/main/examples/vite),
+[React + Vite](https://github.com/evoluhq/evolu/tree/main/examples/react-vite),
+[React + Vite PWA](https://github.com/evoluhq/evolu/tree/main/examples/react-vite-pwa),
 [Electron](https://github.com/evoluhq/evolu/tree/main/examples/electron-app),
 [Expo](https://github.com/evoluhq/evolu/tree/main/apps/native),
 [Remix](https://github.com/evoluhq/evolu/tree/main/examples/remix).


### PR DESCRIPTION
Updates example links in installation.mdx

`...examples/vite` -> `.../react-vite`
adds `.../react-vite-pwa` link