### PR TITLE
Bump pnpm version to 9.10.0 because pnpm keeps complaining about it.

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "turbo": "^2.0.4",
     "typedoc": "^0.26.0"
   },
-  "packageManager": "pnpm@9.9.0",
+  "packageManager": "pnpm@9.10.0",
   "pnpm": {
     "peerDependencyRules": {
       "ignoreMissing": [


### PR DESCRIPTION
Bumps the pnpm version because pnpm complained about it when I installed all the packages lol. Because the project uses corepack, you'll either automatically have it upgraded or will be prompted to upgrade with a single command.