### PR TITLE
Fix: Update 404 URLs in the example section of docs

### DIFF
--- a/apps/web/pages/examples/electron.mdx
+++ b/apps/web/pages/examples/electron.mdx
@@ -1,3 +1,3 @@
 # Electron Example
 
-[GitHub Repository](https://github.com/evoluhq/evolu/tree/main/examples/electron-app)
+[GitHub Repository](https://github.com/evoluhq/evolu/tree/main/examples/react-electron)

--- a/apps/web/pages/examples/vite-react-pwa.mdx
+++ b/apps/web/pages/examples/vite-react-pwa.mdx
@@ -1,3 +1,3 @@
 # Vite React PWA Example
 
-[GitHub Repository](https://github.com/evoluhq/evolu/tree/main/examples/vite-react-pwa)
+[GitHub Repository](https://github.com/evoluhq/evolu/tree/main/examples/react-vite-pwa)

--- a/apps/web/pages/examples/vite.mdx
+++ b/apps/web/pages/examples/vite.mdx
@@ -1,3 +1,3 @@
 # Vite Example
 
-[GitHub Repository](https://github.com/evoluhq/evolu/tree/main/examples/vite)
+[GitHub Repository](https://github.com/evoluhq/evolu/tree/main/examples/react-vite)


### PR DESCRIPTION
Fix all links throwing 404 in the examples page of the docs :). 

...examples/vite -> .../react-vite etc. 