### PR TITLE
Update deps of examples/angular-vite-pwa to latest

### DIFF
--- a/examples/angular-vite-pwa/package.json
+++ b/examples/angular-vite-pwa/package.json
@@ -18,11 +18,11 @@
     "@analogjs/vite-plugin-angular": "^2.1.1",
     "@angular/build": "^21.0.1",
     "@angular/compiler-cli": "^21.0.1",
-    "@tailwindcss/vite": "^4.1.17",
-    "@vite-pwa/assets-generator": "^1.0.2",
-    "tailwindcss": "^4.1.17",
-    "typescript": "^5.9.3",
-    "vite": "^7.2.4",
-    "vite-plugin-pwa": "^1.2.0"
+    "@tailwindcss/vite": "^4.1.14",
+    "@vite-pwa/assets-generator": "^1.0.0",
+    "tailwindcss": "^4.1.12",
+    "typescript": "^5.9.2",
+    "vite": "^7.1.3",
+    "vite-plugin-pwa": "^1.0.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -263,10 +263,10 @@ importers:
         version: 21.0.1(@angular/common@20.3.14(@angular/core@21.0.1(@angular/compiler@20.3.14)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.0.1(@angular/compiler@20.3.14)(rxjs@7.8.2))
       '@evolu/common':
         specifier: latest
-        version: 7.3.0
+        version: 7.4.0
       '@evolu/web':
         specifier: latest
-        version: 2.3.0(@evolu/common@7.3.0)
+        version: 2.4.0(@evolu/common@7.4.0)
     devDependencies:
       '@analogjs/vite-plugin-angular':
         specifier: ^2.1.1
@@ -278,35 +278,35 @@ importers:
         specifier: ^21.0.1
         version: 21.0.1(@angular/compiler@20.3.14)(typescript@5.9.3)
       '@tailwindcss/vite':
-        specifier: ^4.1.17
+        specifier: ^4.1.14
         version: 4.1.17(vite@7.2.4(@types/node@22.19.1)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.93.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1))
       '@vite-pwa/assets-generator':
-        specifier: ^1.0.2
+        specifier: ^1.0.0
         version: 1.0.2
       tailwindcss:
-        specifier: ^4.1.17
+        specifier: ^4.1.12
         version: 4.1.17
       typescript:
-        specifier: ^5.9.3
+        specifier: ^5.9.2
         version: 5.9.3
       vite:
-        specifier: ^7.2.4
+        specifier: ^7.1.3
         version: 7.2.4(@types/node@22.19.1)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.93.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)
       vite-plugin-pwa:
-        specifier: ^1.2.0
+        specifier: ^1.0.2
         version: 1.2.0(@vite-pwa/assets-generator@1.0.2)(vite@7.2.4(@types/node@22.19.1)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.93.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1))(workbox-build@7.4.0(@types/babel__core@7.20.5))(workbox-window@7.4.0)
 
   examples/react-electron:
     dependencies:
       '@evolu/common':
         specifier: latest
-        version: 7.3.0
+        version: 7.4.0
       '@evolu/react':
         specifier: latest
-        version: 10.3.0(@evolu/common@7.3.0)(react@19.1.0)
+        version: 10.4.0(@evolu/common@7.4.0)(react@19.1.0)
       '@evolu/react-web':
         specifier: latest
-        version: 2.3.0(@evolu/common@7.3.0)(@evolu/web@2.3.0(@evolu/common@7.3.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 2.4.0(@evolu/common@7.4.0)(@evolu/web@2.4.0(@evolu/common@7.4.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react:
         specifier: 19.1.0
         version: 19.1.0
@@ -349,13 +349,13 @@ importers:
         version: 1.0.0(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       '@evolu/common':
         specifier: latest
-        version: 7.3.0
+        version: 7.4.0
       '@evolu/react':
         specifier: latest
-        version: 10.3.0(@evolu/common@7.3.0)(react@19.1.0)
+        version: 10.4.0(@evolu/common@7.4.0)(react@19.1.0)
       '@evolu/react-native':
         specifier: latest
-        version: 14.2.0(@evolu/common@7.3.0)(@evolu/react@10.3.0(@evolu/common@7.3.0)(react@19.1.0))(@op-engineering/op-sqlite@15.1.1(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(expo-secure-store@15.0.7(expo@54.0.25))(expo-sqlite@16.0.9(expo@54.0.25)(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(expo@54.0.25)(react-native-nitro-modules@0.31.10(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-svg@15.15.0(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))
+        version: 14.3.0(@evolu/common@7.4.0)(@evolu/react@10.4.0(@evolu/common@7.4.0)(react@19.1.0))(@op-engineering/op-sqlite@15.1.1(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(expo-secure-store@15.0.7(expo@54.0.25))(expo-sqlite@16.0.9(expo@54.0.25)(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(expo@54.0.25)(react-native-nitro-modules@0.31.10(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-svg@15.15.0(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))
       '@expo/metro-runtime':
         specifier: ^6.1.2
         version: 6.1.2(expo@54.0.25)(react-dom@19.1.0(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
@@ -425,13 +425,13 @@ importers:
     dependencies:
       '@evolu/common':
         specifier: latest
-        version: 7.3.0
+        version: 7.4.0
       '@evolu/react':
         specifier: latest
-        version: 10.3.0(@evolu/common@7.3.0)(react@19.1.0)
+        version: 10.4.0(@evolu/common@7.4.0)(react@19.1.0)
       '@evolu/react-web':
         specifier: latest
-        version: 2.3.0(@evolu/common@7.3.0)(@evolu/web@2.3.0(@evolu/common@7.3.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 2.4.0(@evolu/common@7.4.0)(@evolu/web@2.4.0(@evolu/common@7.4.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@tabler/icons-react':
         specifier: ^3.35.0
         version: 3.35.0(react@19.1.0)
@@ -486,13 +486,13 @@ importers:
     dependencies:
       '@evolu/common':
         specifier: latest
-        version: 7.3.0
+        version: 7.4.0
       '@evolu/react':
         specifier: latest
-        version: 10.3.0(@evolu/common@7.3.0)(react@19.1.0)
+        version: 10.4.0(@evolu/common@7.4.0)(react@19.1.0)
       '@evolu/react-web':
         specifier: latest
-        version: 2.3.0(@evolu/common@7.3.0)(@evolu/web@2.3.0(@evolu/common@7.3.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 2.4.0(@evolu/common@7.4.0)(@evolu/web@2.4.0(@evolu/common@7.4.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@tabler/icons-react':
         specifier: ^3.35.0
         version: 3.35.0(react@19.1.0)
@@ -607,13 +607,13 @@ importers:
     dependencies:
       '@evolu/common':
         specifier: latest
-        version: 7.3.0
+        version: 7.4.0
       '@evolu/vue':
         specifier: latest
-        version: 1.3.0(@evolu/common@7.3.0)(vue@3.5.25(typescript@5.9.3))
+        version: 1.4.0(@evolu/common@7.4.0)(vue@3.5.25(typescript@5.9.3))
       '@evolu/web':
         specifier: latest
-        version: 2.3.0(@evolu/common@7.3.0)
+        version: 2.4.0(@evolu/common@7.4.0)
       vue:
         specifier: ^3.5.24
         version: 3.5.25(typescript@5.9.3)
@@ -2351,16 +2351,16 @@ packages:
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@evolu/common@7.3.0':
-    resolution: {integrity: sha512-lEUTPgQdWW/j2JuDxOMwHwRNA/WErtBeb2rlJI4pj1Jsf+kMMWVt2vUB1L1VIAB9QDwGztfOm/LeAzXSLX4yLQ==}
+  '@evolu/common@7.4.0':
+    resolution: {integrity: sha512-5xC2s0B45Lg4Y0Kup3cKQQOYIIrRgjT6jsq8ndQJFFCiEeYE/Wx1LW1Js+7lmNS6fJITvU99jJHYiFFVSwfMuA==}
     engines: {node: '>=22.0.0'}
 
-  '@evolu/react-native@14.2.0':
-    resolution: {integrity: sha512-V+TUt8B4FGDZhHaSHWbdyXGm+blqCZ9OTIYtosFW/uDy4tOeSQseby52QMcjfmxDv/ZcszvJqquQ28BlpWuszQ==}
+  '@evolu/react-native@14.3.0':
+    resolution: {integrity: sha512-/HfypD6F1WrJw2DNcipbDjfFPmy5ebezNNI//GOvy6wCejk/QxPUCNCPksR9akA+UIdqvE1fE9Xct65bBK1e9w==}
     engines: {node: '>=22.0.0'}
     peerDependencies:
-      '@evolu/common': ^7.3.0
-      '@evolu/react': ^10.3.0
+      '@evolu/common': ^7.4.0
+      '@evolu/react': ^10.4.0
       '@op-engineering/op-sqlite': '>=12'
       expo: '>=54'
       expo-secure-store: '>=15'
@@ -2385,38 +2385,38 @@ packages:
       react-native-svg:
         optional: true
 
-  '@evolu/react-web@2.3.0':
-    resolution: {integrity: sha512-Ollt3u8OM3ns60aoTErkvvyRz4xufr08pyss4GiGoR/h50Wl87smz/hoomKoUTZOh0fAl1mg6hCwVf2sdDU/ZA==}
+  '@evolu/react-web@2.4.0':
+    resolution: {integrity: sha512-8zf/qQM+JZWykh0eGIAhE3CRFptGB0FwyQa4jp5Ce7yyOkekRMRs5WMZQA9QbRoY/OBRyOcwIP4aUk/tj49VwQ==}
     engines: {node: '>=22.0.0'}
     peerDependencies:
-      '@evolu/common': ^7.3.0
-      '@evolu/web': ^2.3.0
+      '@evolu/common': ^7.4.0
+      '@evolu/web': ^2.4.0
       react: '>=19'
       react-dom: '>=19'
 
-  '@evolu/react@10.3.0':
-    resolution: {integrity: sha512-hl2ZYK14QXSA4eTzoDtdP086MaShtS85T53YAiWasMnqgLYrZpBGpCB4EEWUswyzd6FC5o2abP8o5w5+eg78zQ==}
+  '@evolu/react@10.4.0':
+    resolution: {integrity: sha512-BLXlLT+/dKSei/JrkLc9Z3fRb48vcXQmaExe0VMdxMzv2h8CyO5l4G635eQtH8F7I40VsnXLCURxNyzKF9DEQw==}
     engines: {node: '>=22.0.0'}
     peerDependencies:
-      '@evolu/common': ^7.3.0
+      '@evolu/common': ^7.4.0
       react: '>=19'
 
   '@evolu/sqlite-wasm@2.2.4':
     resolution: {integrity: sha512-/JOYGFN93QspD2C8HVxVgBUlFWqJ1IpaVuIhEB53u4+ZvE+D3LjpNHDYiwZgf0n7VaH2U85OY5eV3wUrWc3scg==}
     hasBin: true
 
-  '@evolu/vue@1.3.0':
-    resolution: {integrity: sha512-e4XPr30GH9CPBlu108T7zf0eGhSBAu4NO6AUpJc4AISCg4EsOr3qFayolD9CgeaoEVKjNeXZoN19/KrMcxieKA==}
+  '@evolu/vue@1.4.0':
+    resolution: {integrity: sha512-ydT8VxDOIXqfC6n6NQxXPsDX+Jvqg/CP+2Tj8hzZgqFO6PZpIBqOX8pS6ceqVCv+9FI4pC+LGyz4X9idrdX87g==}
     engines: {node: '>=22.0.0'}
     peerDependencies:
-      '@evolu/common': ^7.3.0
+      '@evolu/common': ^7.4.0
       vue: '>=3.5.24'
 
-  '@evolu/web@2.3.0':
-    resolution: {integrity: sha512-jf2DUZHlHaszus2CCcezacbZNLPoN/7lwh9f8mN9KxsJCYmJcDul2Z3LSu8K0k9JGvdGenJzAUsJlRPZ9WewKg==}
+  '@evolu/web@2.4.0':
+    resolution: {integrity: sha512-yba/zpcsf5qu4NEup/rx8j+M/7DmF53/EZXKe8NRJefPJxrCxjzteOgUqUMkHQwYDRdH3u81KMoPlhvdBgSFuQ==}
     engines: {node: '>=22.0.0'}
     peerDependencies:
-      '@evolu/common': ^7.3.0
+      '@evolu/common': ^7.4.0
 
   '@expo/cli@54.0.16':
     resolution: {integrity: sha512-hY/OdRaJMs5WsVPuVSZ+RLH3VObJmL/pv5CGCHEZHN2PxZjSZSdctyKV8UcFBXTF0yIKNAJ9XLs1dlNYXHh4Cw==}
@@ -11604,7 +11604,7 @@ snapshots:
       '@eslint/core': 0.17.0
       levn: 0.4.1
 
-  '@evolu/common@7.3.0':
+  '@evolu/common@7.4.0':
     dependencies:
       '@noble/ciphers': 2.0.1
       '@noble/hashes': 2.0.1
@@ -11613,10 +11613,10 @@ snapshots:
       msgpackr: 1.11.5
       random: 5.4.1
 
-  '@evolu/react-native@14.2.0(@evolu/common@7.3.0)(@evolu/react@10.3.0(@evolu/common@7.3.0)(react@19.1.0))(@op-engineering/op-sqlite@15.1.1(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(expo-secure-store@15.0.7(expo@54.0.25))(expo-sqlite@16.0.9(expo@54.0.25)(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(expo@54.0.25)(react-native-nitro-modules@0.31.10(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-svg@15.15.0(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))':
+  '@evolu/react-native@14.3.0(@evolu/common@7.4.0)(@evolu/react@10.4.0(@evolu/common@7.4.0)(react@19.1.0))(@op-engineering/op-sqlite@15.1.1(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(expo-secure-store@15.0.7(expo@54.0.25))(expo-sqlite@16.0.9(expo@54.0.25)(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(expo@54.0.25)(react-native-nitro-modules@0.31.10(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-svg@15.15.0(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))':
     dependencies:
-      '@evolu/common': 7.3.0
-      '@evolu/react': 10.3.0(@evolu/common@7.3.0)(react@19.1.0)
+      '@evolu/common': 7.4.0
+      '@evolu/react': 10.4.0(@evolu/common@7.4.0)(react@19.1.0)
       react-native: 0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0)
     optionalDependencies:
       '@op-engineering/op-sqlite': 15.1.1(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
@@ -11626,28 +11626,28 @@ snapshots:
       react-native-nitro-modules: 0.31.10(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       react-native-svg: 15.15.0(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
 
-  '@evolu/react-web@2.3.0(@evolu/common@7.3.0)(@evolu/web@2.3.0(@evolu/common@7.3.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+  '@evolu/react-web@2.4.0(@evolu/common@7.4.0)(@evolu/web@2.4.0(@evolu/common@7.4.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
-      '@evolu/common': 7.3.0
-      '@evolu/web': 2.3.0(@evolu/common@7.3.0)
+      '@evolu/common': 7.4.0
+      '@evolu/web': 2.4.0(@evolu/common@7.4.0)
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
 
-  '@evolu/react@10.3.0(@evolu/common@7.3.0)(react@19.1.0)':
+  '@evolu/react@10.4.0(@evolu/common@7.4.0)(react@19.1.0)':
     dependencies:
-      '@evolu/common': 7.3.0
+      '@evolu/common': 7.4.0
       react: 19.1.0
 
   '@evolu/sqlite-wasm@2.2.4': {}
 
-  '@evolu/vue@1.3.0(@evolu/common@7.3.0)(vue@3.5.25(typescript@5.9.3))':
+  '@evolu/vue@1.4.0(@evolu/common@7.4.0)(vue@3.5.25(typescript@5.9.3))':
     dependencies:
-      '@evolu/common': 7.3.0
+      '@evolu/common': 7.4.0
       vue: 3.5.25(typescript@5.9.3)
 
-  '@evolu/web@2.3.0(@evolu/common@7.3.0)':
+  '@evolu/web@2.4.0(@evolu/common@7.4.0)':
     dependencies:
-      '@evolu/common': 7.3.0
+      '@evolu/common': 7.4.0
       '@evolu/sqlite-wasm': 2.2.4
       idb-keyval: 6.2.2
 
@@ -15354,7 +15354,7 @@ snapshots:
       '@next/eslint-plugin-next': 16.0.5
       eslint: 9.39.1(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.1(jiti@2.6.1))
@@ -15377,7 +15377,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -15392,14 +15392,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.1(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -15414,7 +15414,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.1(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -19155,7 +19155,7 @@ snapshots:
     dependencies:
       decode-ico: 0.4.1
       ico-endec: 0.1.6
-      sharp: 0.33.5
+      sharp: 0.34.5
 
   sharp@0.33.5:
     dependencies:


### PR DESCRIPTION
This pull request updates all dependencies of examples/angular-vite-pwa to their latest versions. This includes an Angular upgrade from 20 to 21, which contains no breaking changes for this project.