### PR TITLE
Fix encryption in Expo example

### DIFF
--- a/examples/react-expo/app.json
+++ b/examples/react-expo/app.json
@@ -44,7 +44,7 @@
       ],
       [
         "expo-sqlite", {
-          "useSqlCipher": true
+          "useSQLCipher": true
         }
       ]
     ],


### PR DESCRIPTION
- The parameter used incorrect casing.