### PR TITLE
Small documentation improvements

### DIFF
--- a/apps/web/src/app/(docs)/docs/page.mdx
+++ b/apps/web/src/app/(docs)/docs/page.mdx
@@ -12,12 +12,12 @@ Evolu is both a **TypeScript library** and a **local-first platform**. Choose yo
 
 ## TypeScript library
 
-For anyone who wants to write TypeScript code that scales. Built on proven design patterns like **Result**, **dependency injection**, **structured concurrency**, **immutability** and more. Created by someone who spent years with functional programming, but then [decided to go back](http://localhost:3000/blog/scaling-local-first-software#rewriting-evolu-fp-ts-effect-evolu-library) to the simple and idiomatic TypeScript code—no pipes, no black-box abstractions, no unreadable stacktraces.
+For anyone who wants to write TypeScript code that scales. Built on proven design patterns like **Result**, **dependency injection**, **structured concurrency**, **immutability** and more. Created by someone who spent years with functional programming, but then [decided to go back](/blog/scaling-local-first-software#rewriting-evolu-fp-ts-effect-evolu-library) to the simple and idiomatic TypeScript code—no pipes, no black-box abstractions, no unreadable stacktraces.
 
 [**Get started with the library** →](/docs/library)
 
 ## Local-first platform
 
-A complete platform for building apps where users own their data. Works offline-first with sync via self-hostable or cloud relays. End-to-end encrypted by default. Built on SQLite with a scalable sync protocol designed for real-world use. No vendor lock-in, no data hostage situations.
+A complete platform for building apps where users own their data. Works offline-first with sync via self-hosted or cloud relays. End-to-end encrypted by default. Built on SQLite with a scalable sync protocol designed for real-world use. No vendor lock-in, no data hostage situations.
 
 [**Get started with local-first** →](/docs/local-first)

--- a/apps/web/src/app/(docs)/docs/showcase/page.mdx
+++ b/apps/web/src/app/(docs)/docs/showcase/page.mdx
@@ -3,18 +3,20 @@ export const metadata = {
   description: "Real-world apps built with Evolu.",
 };
 
+# Showcase
+
 ## finbodhi
 
 [finbodhi](https://finbodhi.com) is a financial app for tracking income, expenses, and investments with privacy-first local-first design.
 
 ## Starpy
 
-[Starpy](https://www.starpy.me) is a P2P collaborative video editor and storage app—a single app for cameraman, editor, and director.
+[Starpy](https://www.starpy.me) is a P2P collaborative video editor and storage app, a single app for a cameraman, an editor, and a director.
 
 ## gider.im
 
-[gider.im](https://gider.im) - Privacy focused, income, expense & asset tracking.
+[gider.im](https://gider.im) is a privacy-focused app for income, expense, and asset tracking.
 
 ## hayom
 
-[hayom](https://hayom.pages.dev) is a todo app designed to achieve flow state. It has VIM keybindings, Pomodoro timer and a focus mode.
+[hayom](https://hayom.pages.dev) is a to-do app designed to achieve a flow state. It has Vim keybindings, a Pomodoro timer, and a focus mode.

--- a/apps/web/src/components/Navigation.tsx
+++ b/apps/web/src/components/Navigation.tsx
@@ -100,7 +100,7 @@ const VisibleSectionHighlight = ({
     ? Math.max(1, visibleSections.length) * itemHeight
     : itemHeight;
   const top =
-    group.links.findIndex((link) => link.href === pathname) * itemHeight +
+    group.links.findIndex((link) => pathname.includes(link.href)) * itemHeight +
     firstVisibleSectionIndex * itemHeight;
 
   return (
@@ -125,7 +125,7 @@ const ActivePageMarker = ({
   const itemHeight = remToPx(2);
   const offset = remToPx(0.25);
   const activePageIndex = group.links.findIndex(
-    (link) => link.href === pathname,
+    (link) => pathname.includes(link.href),
   );
   const top = offset + activePageIndex * itemHeight;
 
@@ -158,7 +158,7 @@ const NavigationGroup = ({
   );
 
   const isActiveGroup =
-    group.links.findIndex((link) => link.href === pathname) !== -1;
+    group.links.findIndex((link) => pathname.includes(link.href)) !== -1;
 
   return (
     <li className={clsx("relative mt-6", className)}>
@@ -186,12 +186,12 @@ const NavigationGroup = ({
         <ul role="list" className="border-l border-transparent">
           {group.links.map((link) => (
             <motion.li key={link.href} layout="position" className="relative">
-              <NavLink href={link.href} active={link.href === pathname}>
+              <NavLink href={link.href} active={pathname.includes(link.href)}>
                 {link.title}{" "}
                 {link.href.startsWith("http") && <IconArrowUpRight />}
               </NavLink>
               <AnimatePresence mode="popLayout" initial={false}>
-                {link.href === pathname && sections.length > 0 && (
+                {pathname.includes(link.href) && sections.length > 0 && (
                   <motion.ul
                     role="list"
                     initial={{ opacity: 0 }}
@@ -207,7 +207,7 @@ const NavigationGroup = ({
                     {sections.map((section) => (
                       <li key={section.id}>
                         <NavLink
-                          href={`${link.href}#${section.id}`}
+                          href={`${pathname}#${section.id}`}
                           tag={section.tag}
                           isAnchorLink
                         >

--- a/apps/web/src/components/Navigation.tsx
+++ b/apps/web/src/components/Navigation.tsx
@@ -13,6 +13,12 @@ import { type NavGroup, navigation } from "@/lib/navigation";
 import { remToPx } from "@/lib/remToPx";
 import { IconArrowUpRight } from "@tabler/icons-react";
 
+const isPathActive = (href: string, pathname: string): boolean => {
+  const segmentCount = href.split("/").filter(Boolean).length;
+  if (segmentCount < 2) return href === pathname; // exact match for top-level paths
+  return href === pathname || pathname.startsWith(`${href}/`);
+};
+
 const useInitialValue = <T,>(value: T, condition = true) => {
   const [initialValue] = useState(value);
   return condition ? initialValue : value;
@@ -100,7 +106,7 @@ const VisibleSectionHighlight = ({
     ? Math.max(1, visibleSections.length) * itemHeight
     : itemHeight;
   const top =
-    group.links.findIndex((link) => pathname.includes(link.href)) * itemHeight +
+    group.links.findIndex((link) => isPathActive(link.href, pathname)) * itemHeight +
     firstVisibleSectionIndex * itemHeight;
 
   return (
@@ -125,7 +131,7 @@ const ActivePageMarker = ({
   const itemHeight = remToPx(2);
   const offset = remToPx(0.25);
   const activePageIndex = group.links.findIndex(
-    (link) => pathname.includes(link.href),
+    (link) => isPathActive(link.href, pathname),
   );
   const top = offset + activePageIndex * itemHeight;
 
@@ -158,7 +164,7 @@ const NavigationGroup = ({
   );
 
   const isActiveGroup =
-    group.links.findIndex((link) => pathname.includes(link.href)) !== -1;
+    group.links.findIndex((link) => isPathActive(link.href, pathname)) !== -1;
 
   return (
     <li className={clsx("relative mt-6", className)}>
@@ -186,12 +192,12 @@ const NavigationGroup = ({
         <ul role="list" className="border-l border-transparent">
           {group.links.map((link) => (
             <motion.li key={link.href} layout="position" className="relative">
-              <NavLink href={link.href} active={pathname.includes(link.href)}>
+              <NavLink href={link.href} active={isPathActive(link.href, pathname)}>
                 {link.title}{" "}
                 {link.href.startsWith("http") && <IconArrowUpRight />}
               </NavLink>
               <AnimatePresence mode="popLayout" initial={false}>
-                {pathname.includes(link.href) && sections.length > 0 && (
+                {isPathActive(link.href, pathname) && sections.length > 0 && (
                   <motion.ul
                     role="list"
                     initial={{ opacity: 0 }}

--- a/packages/common/src/local-first/Owner.ts
+++ b/packages/common/src/local-first/Owner.ts
@@ -200,7 +200,7 @@ const createOwner = (secret: OwnerSecret): Owner => ({
  *
  * AppOwner must never be shared with anyone.
  *
- * AppOwner's {@link OwnerId} is used for authorization with
+ * AppOwner's {@link OwnerId} is used for authentization with
  * {@link createOwnerWebSocketTransport}. Share it only with trusted relay
  * parties that must verify access, and do not share it with anyone else.
  *


### PR DESCRIPTION
Changes:

- Active page indicator (in left sidebar) wasn't working for nested paths, like [/api-reference/react](https://www.evolu.dev/docs/api-reference/react) due to exact regex pattern matching (`===`). Added "includes" matching (`pathname.startsWith()`) for nested paths, but kept the exact matching for top-level paths (otherwise Overview page with `/docs` path would get matched every time)
- Fixed hardcoded blog links
- Added missing heading in Showcase and fixed some minor grammar issues
- Reword AppOwner docs, because is's technically used for authz, not authn (yes, I also didn't know the difference until like last week)

Also, if you have some other docs changes in mind, I can work on them as well and include them to this PR. I was maybe thinking that Owners and Protocol would deserve their own docs page instead of just API reference link, so maybe prepare some draft for that?