### PR TITLE
Fix schedule overflow crash after ~21 min of WebSocket retrying

### DIFF
--- a/packages/common/src/Schedule.ts
+++ b/packages/common/src/Schedule.ts
@@ -11,6 +11,7 @@ import type { repeat, RepeatAttempt, retry, RetryAttempt } from "./Task.js";
 import {
   type Duration,
   durationToMillis,
+  maxMillis,
   Millis,
   minMillis,
   type TimeDep,
@@ -211,6 +212,10 @@ export const spaced =
     return () => ok([ms, ms]);
   };
 
+/** Clamps a computed delay to the valid {@link Millis} range, saturating at {@link maxMillis}. */
+const clampToMillis = (raw: number): Millis =>
+  Math.round(raw) >= maxMillis ? maxMillis : Millis.orThrow(Math.max(0, Math.round(raw)));
+
 /**
  * Exponential backoff schedule.
  *
@@ -243,7 +248,7 @@ export const exponential =
     return () => {
       attempt++;
       const rawDelay = baseMs * Math.pow(factor, attempt - 1);
-      const delay = Millis.orThrow(Math.max(0, Math.round(rawDelay)));
+      const delay = clampToMillis(rawDelay);
       return ok([delay, delay]);
     };
   };
@@ -276,7 +281,7 @@ export const linear =
     let attempt = 0;
     return () => {
       attempt++;
-      const delay = Millis.orThrow(ms * attempt);
+      const delay = clampToMillis(ms * attempt);
       return ok([delay, delay]);
     };
   };
@@ -310,7 +315,7 @@ export const fibonacci =
     const ms = durationToMillis(initial);
     let index = 1;
     return () => {
-      const delay = Millis.orThrow(
+      const delay = clampToMillis(
         ms * fibonacciAt(FibonacciIndex.orThrow(index)),
       );
       index++;

--- a/packages/common/test/Schedule.test.ts
+++ b/packages/common/test/Schedule.test.ts
@@ -250,6 +250,14 @@ describe("exponential", () => {
     // step1 continues from its data
     expectOk(step1(undefined), [400, 400]);
   });
+
+  test("saturates at maxMillis instead of throwing on overflow", () => {
+    const deps = createScheduleDeps();
+    const step = exponential("100ms")(deps);
+    // Advance to attempt 43 where 100 * 2^42 > maxMillis
+    for (let i = 0; i < 42; i++) step(undefined);
+    expect(step(undefined)).toEqual(ok([maxMillis, maxMillis]));
+  });
 });
 
 describe("linear", () => {


### PR DESCRIPTION
Unbounded schedule constructors (exponential, linear, fibonacci) called Millis.orThrow on computed delays that grow without bound. When composed with maxDelay, the inner schedule throws before the capping combinator runs. For the WebSocket reconnection schedule, this crashes at attempt 43 when 100 * 2^42 exceeds the Millis max (2^48 - 1).

Saturate at maxMillis instead of throwing, so limiting combinators can do their job at any attempt count.